### PR TITLE
Allow Different Sampling Approaches with Arguments

### DIFF
--- a/bin/app-sample
+++ b/bin/app-sample
@@ -29,7 +29,7 @@ def writeParams(P, templates, outdir, fname="params.dat"):
             with open(tname, "w") as tf:
                 tf.write(txt)
 
-def sample(boxdef, npoints):
+def sample(boxdef, npoints, method):
     is_json=True;
     import json
     with open(boxdef) as f:
@@ -50,28 +50,45 @@ def sample(boxdef, npoints):
     xmin = [B[x][0] for x in porder]
     xmax = [B[x][1] for x in porder]
 
-    # Randomly sampled points
-    # TODO add lhs as preferred option?
-    RSP = np.random.uniform(low=xmin, high=xmax,size=(npoints, len(xmin)))
+    print(xmin, xmax)
+    
+    sampled_points=[]
+    if(method=="RSP"): # randomly sampled points
+        sampled_points = np.random.uniform(low=xmin, high=xmax,size=(npoints, len(xmin)))
+    elif(method=="LHS"): # latin hypercube sampling
+        from scipy.stats import qmc
+        sampler = qmc.LatinHypercube(d=len(B.keys()))
+        sample = sampler.random(n=npoints)
+        sampled_points = qmc.scale(sample, xmin, xmax)
+    else:
+        throw("app-sample\tERROR\tUnknown sampling method.")
+        
     for p in porder:
         print(p)
 
+    print(sampled_points)
+        
     # As dictionaries
-    return [ dict(zip(porder, x)) for x in RSP]
+    return [ dict(zip(porder, x)) for x in sampled_points ]
 
 
 if __name__=="__main__":
     import sys
-    PP = sample(sys.argv[1], int(sys.argv[2]))
 
     # First arg: json with param box
     # 2nd arg: number of points to sample i.e. number of sub directories to create
     # 3rd arg: template
+    # 4th arg: sampling method
 
     import os
     tname = os.path.basename(sys.argv[3])
     TEMPLATES={}
     with open(sys.argv[3], "r") as f:
         TEMPLATES[tname] = f.read()
-
-    writeParams(PP, TEMPLATES, "newscan")
+        
+    if(len(sys.argv)==4):
+        PP = sample(sys.argv[1], int(sys.argv[2]), "RSP")
+        writeParams(PP, TEMPLATES, "newscan")
+    elif(len(sys.argv)==5):
+        PP = sample(sys.argv[1], int(sys.argv[2]), sys.argv[4])
+        writeParams(PP, TEMPLATES, "newscan")


### PR DESCRIPTION
Hi,

We'd like to be able to use sampling approaches other than uniform random sampling when constructing grids. In particular, we'd like to at least try out using Latin Hypercube sampling, but there might be other interesting approaches to try. I've very quickly implemented LHS in the `bin/app-sample` script (_n.b._ this has not been carefully validated yet), and made these sampling methods configurable with a command-line argument when calling the script.

It is much more desirable to have such functionality implemented with command-line options rather than being left to users to edit -- for example, for our use case, we'd like to use apprentice in part of a containerized workflow. This makes it inconvenient to patch dependencies when our pipelines are running. That is of course also an option, so please let us know if you'd prefer us to just such alterations locally.

I believe that the way I have implemented the extra option should maintain backwards compatibility, but the way I have done this is somewhat ugly, due to the preexisting use of `sys.argv` here. 

`scipy` is only needed if the new `LHS` argument is passed.

Cheers,
Matt