### PR TITLE
Fix YODA 2.x mkScatter() path loss and NumPy object-array encoding in io.py

### DIFF
--- a/apprentice/io.py
+++ b/apprentice/io.py
@@ -179,8 +179,11 @@ def writeInputDataSetH5(fname, data, runs, BNAMES, pnames, xmin, xmax, compressi
 
     # TODO change encoding to fixed size ascii
     # https://github.com/h5py/h5py/issues/892
-    f.create_dataset("runs",  data=np.char.encode(runs,   encoding='utf8'),  compression=compression)
-    f.create_dataset("index", data=np.char.encode(BNAMES, encoding='utf8'),  compression=compression)
+    # np.char.encode fails on object arrays in newer NumPy; encode manually
+    runs_enc   = np.array([r.encode('utf8') if isinstance(r, str) else r for r in runs])
+    bnames_enc = np.array([b.encode('utf8') if isinstance(b, str) else b for b in BNAMES])
+    f.create_dataset("runs",  data=runs_enc,   compression=compression)
+    f.create_dataset("index", data=bnames_enc, compression=compression)
     pset = f.create_dataset("params", data=data[0][0], compression=compression)
     pset.attrs["names"] = [x.encode('utf8') for x in pnames]
 
@@ -201,7 +204,7 @@ def read_histos(path):
         return read_yoda_pre180(path)
 
     histos = {}
-    s2s, types = [], []
+    s2s, types, paths = [], [], []
     aos = yoda.read(path, asdict=False)
     try:
         for ao in aos:
@@ -209,12 +212,13 @@ def read_histos(path):
             if os.path.basename(ao.path()).startswith("_"): continue
             if "/RAW/" in ao.path(): continue
             types.append(ao.type())
+            paths.append(ao.path())   # preserve path before mkScatter() loses it
             s2s.append(ao.mkScatter())
         del aos
-        for s2, tp in zip(s2s, types):
+        for s2, tp, aopath in zip(s2s, types, paths):
             if s2.dim()!=2: continue
             bins = [(p.xMin(), p.xMax(), p.y(), p.yErrAvg()) for p in s2.points()] # This stores the bin heights as y-values
-            histos[s2.path()] = bins
+            histos[aopath] = bins   # use original AO path, not s2.path()
         del s2s
     except Exception as e:
         print("read_histos --- Can't load histos from file '%s': %s" % (path, e))


### PR DESCRIPTION

Two bug fixes in `apprentice/io.py` for compatibility with YODA ≥ 2.0 and
NumPy ≥ 1.20. Both were discovered while running Apprentice against a
Rivet 4.x / YODA 2.1.2 output.

---

**Fix 1 — `writeInputDataSetH5`: `np.char.encode` fails on object arrays**

**Affected function:** `writeInputDataSetH5`

In NumPy ≥ 1.20, `np.char.encode` requires its input to have a proper
Unicode string dtype (`U...`). Arrays produced by the YODA 2.x reader are
Python object arrays, causing:

```
TypeError: ufunc 'encode' not supported for the input types ...
```

**Fix:** encode the strings explicitly in a list comprehension before
passing to `h5py`:

```python
# Before
f.create_dataset("runs",  data=np.char.encode(runs,   encoding='utf8'), ...)
f.create_dataset("index", data=np.char.encode(BNAMES, encoding='utf8'), ...)

# After
runs_enc   = np.array([r.encode('utf8') if isinstance(r, str) else r for r in runs])
bnames_enc = np.array([b.encode('utf8') if isinstance(b, str) else b for b in BNAMES])
f.create_dataset("runs",  data=runs_enc,   ...)
f.create_dataset("index", data=bnames_enc, ...)
```

---

**Fix 2 — `read_histos`: `mkScatter()` in YODA 2.x drops the analysis path**

**Affected function:** `read_histos`

In YODA 2.x, `AnalysisObject.mkScatter()` creates a new `Scatter2D`
object whose `.path()` is reset to `'/'`. The original code:

```python
s2s.append(ao.mkScatter())
# ...
histos[s2.path()] = bins   # s2.path() == '/' in YODA 2.x
```

silently stores every histogram under the key `'/'`, overwriting all but
the last one. This produces an HDF5 index containing only `/#0`, `/#1`, …
instead of the real analysis paths, breaking cross-matching with
reference data and the downstream steps.

**Fix:** capture `ao.path()` *before* calling `mkScatter()`:

```python
paths.append(ao.path())   # save before mkScatter() resets it
s2s.append(ao.mkScatter())
# ...
histos[aopath] = bins     # use original AO path
```

---

This is now working fine in my pipeline with YODA 2.1.2 & Rivet 4.1.2...
